### PR TITLE
add FLASK_ENV to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ The ksvotes.org site makes Kansas online voting registration easy.
   TESTING_DATABASE_URL={{your testing database connection string}}
   SECRET_KEY={{generate a secret key}}
   APP_CONFIG=dev
+  FLASK_ENV=development
   CRYPT_KEY={{generate a secret key | base64}}
   ```
 


### PR DESCRIPTION
by default when you run the app you get this message
```
python manage.py runserver
 * Serving Flask app "app" (lazy loading)
 * Environment: production
   WARNING: Do not use the development server in a production environment.
   Use a production WSGI server instead.
```
adding `FLASK_ENV` to the `.env` file quiets it.