### PR TITLE
Fix exception when no registrant defined

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ The ksvotes.org site makes Kansas online voting registration easy.
   GA_KEY={{google analytics key}}
   # RECAPTCHA_KEY={{public key}}
   # RECAPTCHA_SECRET={{private key}}
+  # USPS_USER_ID={{key from https://registration.shippingapis.com/}}
   ```
 
 ### Migrate Database

--- a/app/decorators/insession.py
+++ b/app/decorators/insession.py
@@ -1,25 +1,32 @@
 from functools import wraps
-from flask import request, g, session
+from flask import request, g, session as http_session, redirect
 from app.models import Registrant
-from uuid import UUID
+from uuid import UUID, uuid4
 
-
+# check for session_id cookie, and corresponding Registrant db record.
+# if can't find both, redirect to start page.
 def InSession(f):
     @wraps(f)
     def decorated(*args, **kwargs):
-        session_id = session.get('session_id')
-        if session_id:
-            try:
-                sid = UUID(session_id, version=4)
-                registrant = Registrant.query.filter(Registrant.session_id == sid).first()
-                if registrant:
-                    #set request global to current registrant
-                    g.registrant = registrant
-                else:
-                    #delete invalid registration uuid
-                    session.pop('session_id')
-            except:
-                #if not valid uuid session_id delete
-                session.pop('session_id')
+        session_id = http_session.get('session_id')
+        g.registrant = None
+
+        # if we don't yet have a session_id, assign one.
+        if not session_id:
+            uuid_str = str(uuid4())
+            http_session['session_id'] = uuid_str
+            # edge case: a request "in the middle" of the flow.
+            if request.path != '/':
+                return redirect('/')
+        else:
+            sid = UUID(session_id, version=4)
+            g.registrant = Registrant.query.filter(Registrant.session_id == sid).first()
+
+        # edge case: clear stale cookie and start over.
+        if session_id and not g.registrant:
+            http_session.pop('session_id')
+            return redirect('/')
+
         return f(*args, **kwargs)
+
     return decorated

--- a/app/main/forms/step_0.py
+++ b/app/main/forms/step_0.py
@@ -25,7 +25,6 @@ class FormStep0(FlaskForm):
         time_now = datetime.datetime.utcnow()
         time_dob = datetime.datetime.strptime(field.data, '%m/%d/%Y')
         diff = relativedelta(time_now, time_dob).years
-        print(diff)
         if diff <= 15:
             field.errors.append(gettext('0_dob_help'))
             return False

--- a/app/main/starter_views.py
+++ b/app/main/starter_views.py
@@ -30,24 +30,23 @@ def index():
         if registrant:
             g.registrant.update(form.data)
         else:
+            sid = UUID(http_session.get('session_id'), version=4)
             registrant = Registrant(
                 county = form.data.get('county'),
                 registration_value = form.data,
-                session_id = uuid4()
+                session_id = sid
             )
             db.session.add(registrant)
-            http_session['session_id'] = str(registrant.session_id)
 
-        #run step
         step.run()
-        #update any non form variables/non
         registrant.reg_lookup_complete = step.reg_lookup_complete
         db.session.commit()
 
         session_manager = SessionManager(registrant, step)
         return redirect(session_manager.get_redirect_url())
 
-    return render_template('index.html', form=form)
+    else:
+        return render_template('index.html', form=form)
 
 @main.route('/change-or-apply', methods=["GET", "POST"])
 @InSession

--- a/app/main/tests/test_index.py
+++ b/app/main/tests/test_index.py
@@ -19,7 +19,7 @@ def test_create_new_session_step_0(app, db_session, client):
         registrant = Registrant.query.filter(Registrant.session_id == http_session.get('session_id')).first()
         assert registrant.reg_lookup_complete == True
 
-def test_update_name_step_0_session_exists_already(app,db_session,client):
+def test_update_name_step_0_session_exists_already(app, db_session, client):
     """
     A returning user with a session id updates the existing registrant model.
     """
@@ -69,6 +69,9 @@ def test_registered_voter_input_returns_redirect_step_AB_1(app, db_session, clie
         "email":"foo@example.com",
         "county": "Douglas"
     }
+    with client.session_transaction() as http_session:
+        assert http_session.get('session_id') == None
+
     response = client.post('/', data=form_payload, follow_redirects=False)
     redirect_data = response.data.decode()
     assert ('/change-or-apply' in redirect_data) == True
@@ -78,12 +81,12 @@ def test_unregistered_voter_input_returns_redirect_step_VR_1(app, db_session, cl
     A non registered potential voter returns the step for vr 1.
     """
     form_payload = {
-            "name_first": "foo",
-            "name_last": "bar",
-            "dob":"02/02/1999",
-            "email":"foo@example.com",
-            "county": "Douglas"
-        }
+        "name_first": "foo",
+        "name_last": "bar",
+        "dob":"02/02/1999",
+        "email":"foo@example.com",
+        "county": "Douglas"
+    }
     response = client.post('/', data=form_payload, follow_redirects=False)
     redirect_data = response.data.decode()
     assert ('/vr/citizenship' in redirect_data) == True

--- a/conftest.py
+++ b/conftest.py
@@ -29,10 +29,9 @@ def db(app, request):
         _db.drop_all()
         _db.create_all()
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="function")
 def client(app, request):
     return app.test_client()
-
 
 @pytest.fixture(scope="function", autouse=True)
 def db_session(app, db, request):


### PR DESCRIPTION
This PR does a few things:
* adds `USPS_USER_ID` to README
* makes sure all our unit tests start with a clean session (no sticky `client` fixtures between tests)
* refactors the `InSession` decorator to set the `session_id` cookie *before* saving the Registrant for the first time. This makes it easier to spot the case where the request is for `/some-path-other-than-root` and the `session_id` does not match an existing registrant. Otherwise, an exception was being thrown by controller code trying to access the global `registrant` variable.