### PR TITLE
Use HTML5 email and telephone fields.

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -69,6 +69,11 @@ def create_app(script_info):
     def inject_dict_for_all_templates():
         return dict(registrant=g.get('registrant'))
 
+    @app.template_test('a_text_field')
+    def a_text_field(obj):
+        from wtforms import StringField, DateField
+        return isinstance(obj, StringField) or isinstance(obj, DateField)
+
 
     from app.main import main as main_blueprint
     app.register_blueprint(main_blueprint)

--- a/app/main/forms/step_0.py
+++ b/app/main/forms/step_0.py
@@ -1,6 +1,7 @@
 from flask_wtf import FlaskForm, RecaptchaField
 from wtforms import StringField, SelectField, HiddenField
 from wtforms.validators import DataRequired, Email, Regexp, Optional
+from wtforms.fields.html5 import EmailField, TelField
 from flask_babel import lazy_gettext
 from dateutil.relativedelta import relativedelta
 import datetime
@@ -12,16 +13,22 @@ class FormStep0(FlaskForm):
     ref = HiddenField()
     name_first = StringField(lazy_gettext(u'0_first'), validators=[DataRequired(message=lazy_gettext(u'Required'))])
     name_last = StringField(lazy_gettext(u'0_last'), validators=[DataRequired(message=lazy_gettext(u'Required'))])
-    dob = StringField(lazy_gettext(u'0_dob'), validators=[DataRequired(message=lazy_gettext(u'Required')), Regexp('^\d{2}[\/\-]?\d{2}[\/\-]?\d{4}$', message=lazy_gettext(u'0_dob_flag'))])
+    dob = StringField(
+        lazy_gettext(u'0_dob'),
+        validators=[
+            DataRequired(message=lazy_gettext(u'Required')),
+            Regexp('^\d{2}[\/\-]?\d{2}[\/\-]?\d{4}$', message=lazy_gettext(u'0_dob_flag'))
+        ]
+    )
     county = SelectField(lazy_gettext(u'0_county'),
         validators=[Optional()],
         choices=construct_county_choices(lazy_gettext(u'0_county'))
     )
-    email = StringField(lazy_gettext(u'0_email'),
+    email = EmailField(lazy_gettext(u'0_email'),
         validators=[DataRequired(message=lazy_gettext(u'Required')),
         Email(message=lazy_gettext(u'0_email_flag'))]
     )
-    phone = StringField(lazy_gettext(u'0_phone'),
+    phone = TelField(lazy_gettext(u'0_phone'),
         validators=[Optional(), Regexp('^\d{3}[\-\.]?\d{3}[\-\.]?\d{4}$', message=lazy_gettext(u'0_phone_help'))]
     )
 

--- a/app/templates/macros/_render_field.html
+++ b/app/templates/macros/_render_field.html
@@ -1,6 +1,6 @@
 {% macro render_field(field, help_text, additional_attributes) %}
 
-  {% if field.widget.input_type == 'text' %}
+  {% if field is a_text_field %}
   <div class="md-form pr-4">
       {{field.label}}
 


### PR DESCRIPTION
 Date field control is not ideal for DOB for different browsers. We don't want a full calendar widget on desktop e.g., because it requires paging back 18+ years depending on the user's age.