### PR TITLE
Fix email receipt regression

### DIFF
--- a/app/main/AB/AB7_affirmation.py
+++ b/app/main/AB/AB7_affirmation.py
@@ -37,8 +37,10 @@ def ab7_affirmation():
             r = mailer.send()
 
             # any error gets a special page
-            if 'clerk' not in r or 'MessageId' not in r['clerk']:
-                return render_template('email_error.html', clerk=clerk)
+            for k in ['clerk', 'receipt']:
+                if k not in r or 'MessageId' not in r[k] or not r[k]['MessageId']:
+                    # TODO log New Relic event
+                    return render_template('email_error.html', clerk=clerk)
 
             reg.update({'ab_forms_message_id': r['clerk']['MessageId']})
             reg.save(db.session)

--- a/app/main/VR/VR7_affirmation.py
+++ b/app/main/VR/VR7_affirmation.py
@@ -37,8 +37,10 @@ def vr7_affirmation():
             r = mailer.send()
 
             # any error gets a special page
-            if 'clerk' not in r or 'MessageId' not in r['clerk']:
-                return render_template('email_error.html', clerk=clerk)
+            for k in ['clerk', 'receipt']:
+                if k not in r or 'MessageId' not in r[k] or not r[k]['MessageId']:
+                    # TODO log New Relic event
+                    return render_template('email_error.html', clerk=clerk)
 
             reg.update({'vr_form_message_id': r['clerk']['MessageId']})
             reg.save(db.session)

--- a/app/services/county_mailer.py
+++ b/app/services/county_mailer.py
@@ -114,7 +114,7 @@ class CountyMailer():
         attachments = kwargs['attach'] if 'attach' in kwargs else []
 
         msg = MIMEMultipart()
-        msg['Subject'] = subject
+        msg['Subject'] = str(subject)
         msg['To'] = ', '.join(recip_to)
         msg['Cc'] = ', '.join(recip_cc)
         msg['Bcc'] = ', '.join(recip_bcc)
@@ -154,6 +154,10 @@ class CountyMailer():
             return resp
 
         except botocore.exceptions.ClientError as err:
+            current_app.logger.error(str(err))
+            return {'msg': msg, 'MessageId': False, 'error': err}
+
+        except (RuntimeError, TypeError, NameError) as err:
             current_app.logger.error(str(err))
             return {'msg': msg, 'MessageId': False, 'error': err}
 


### PR DESCRIPTION
Must coerce Babel object into string explicitly before handing to MIME serializer.

Add better error checking.