### PR TITLE
Fix parsley pattern error message for ZIP

### DIFF
--- a/app/templates/ab/address.html
+++ b/app/templates/ab/address.html
@@ -57,10 +57,10 @@
       _('3_zip_help'),
       {
         'required':'required',
-        'data-parsley-error-message': _('Required'),
+        'data-parsley-required-message': _('Required'),
         'autocomplete':'off',
         'data-parsley-trigger':'focusout',
-        'data-parsley-pattern-message': _('0_zip_help'),
+        'data-parsley-pattern-message': _('3_zip_help'),
         'data-parsley-pattern': "/^\d{5}$/",
       }
       )}}
@@ -113,10 +113,10 @@
         form.mail_zip,
         _('3_zip_help'),
         {
-          'data-parsley-error-message': _('Required'),
+          'data-parsley-required-message': _('Required'),
           'autocomplete':'off',
           'data-parsley-trigger':'focusout',
-          'data-parsley-pattern-message': _('0_zip_help'),
+          'data-parsley-pattern-message': _('3_zip_help'),
           'data-parsley-pattern': "/^\d{5}$/",
         }
         )}}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -58,10 +58,10 @@
       {
         'required':'required',
         'pattern': '[0-9]*',
-        'data-parsley-error-message': _('Required'),
+        'data-parsley-required-message': _('Required'),
         'autocomplete':'off',
         'data-parsley-trigger':'focusout',
-        'data-parsley-pattern-message': _('0_zip_help'),
+        'data-parsley-pattern-message': _('3_zip_help'),
         'data-parsley-pattern': "/^\d{5}$/",
       }
       )}}

--- a/app/templates/vr/address.html
+++ b/app/templates/vr/address.html
@@ -56,11 +56,11 @@
       _('3_zip_help'),
       {
         'required':'required',
-        'pattern': '[0-9]*',
-        'data-parsley-error-message': _('Required'),
+        'pattern': '\d{5}',
+        'data-parsley-required-message': _('Required'),
         'autocomplete':'off',
         'data-parsley-trigger':'focusout',
-        'data-parsley-pattern-message': _('0_zip_help'),
+        'data-parsley-pattern-message': _('3_zip_help'),
         'data-parsley-pattern': "/^\d{5}$/",
       }
       )}}
@@ -113,10 +113,10 @@
         _('3_zip_help'),
         {
           'pattern': '[0-9]*',
-          'data-parsley-error-message': _('Required'),
+          'data-parsley-required-message': _('Required'),
           'autocomplete':'off',
           'data-parsley-trigger':'focusout',
-          'data-parsley-pattern-message': _('0_zip_help'),
+          'data-parsley-pattern-message': _('3_zip_help'),
           'data-parsley-pattern': "/^\d{5}$/",
         }
         )}}
@@ -170,10 +170,10 @@
         _('3_zip_help'),
         {
           'pattern': '[0-9]*',
-          'data-parsley-error-message': _('Required'),
+          'data-parsley-required-message': _('Required'),
           'autocomplete':'off',
           'data-parsley-trigger':'focusout',
-          'data-parsley-pattern-message': _('0_zip_help'),
+          'data-parsley-pattern-message': _('3_zip_help'),
           'data-parsley-pattern': "/^\d{5}$/",
         }
         )}}


### PR DESCRIPTION
NOTE there is a trade-off here for UX. In order to trigger the numeric keypad on mobile for ZIP, we must use `pattern="[0-9]*"` but that override the more specific `data-parsley-pattern="^\d{5}$"`. We sacrifice the possibility of POST-response-with-error in exchange for faster keyboard entry.

In either case, the correct message should appear now.