### PR TITLE
Update Pratt County Clerk info

### DIFF
--- a/county-clerks.csv
+++ b/county-clerks.csv
@@ -74,7 +74,7 @@ Ottawa County,OTTAWA,Mary Arganbright,occlerk@ottawaclerk.org,8:00-12:00 1:00-5:
 Pawnee County,PAWNEE,Ruth M. Searight,clerk@pawneecountyks.org,8:30-5:00,6202853721,6202852559,715 Broadway,,Larned,KS,67550
 Phillips County,PHILLIPS,Linda McDowell,coclerk@ruraltel.net,8:00-5:00,7855436825,7855436827,301 State Street,Ste A,Phillipsburg,KS,67661
 Pottawatomie County,POTTAWATOMIE,Nancy McCarter,arice@pottcounty.org,8:30-4:30,7854573314,7854573507,207 N 1st,PO Box 187,Westmoreland,KS,66549
-Pratt County,PRATT,Sherry Kruse,clerk@prattcounty.org,8:00-5:00,6206724110,6206729541,PO Box 885,300 S Ninnescah,Pratt,KS,67124
+Pratt County,PRATT,Lori Voss,lvoss@prattcounty.org,8:00-5:00,6206724110,6206729541,PO Box 885,300 S Ninnescah,Pratt,KS,67124
 Rawlins County,RAWLINS,Rachel Finley,rfinley@rawlinscounty.org,9:00-5:00,7856263351,7856269019,607 Main St.,Suite C,Atwood,KS,67730
 Reno County,RENO,Donna Patton,donna.patton@renogov.org,8:00-5:00,6206942934,6206942534,125 W. 1st Ave,,Hutchinson,KS,67501
 Republic County,REPUBLIC,Kathleen L. Marsicek,kmarsicek@republiccounty.org,8:00-5:00,7855277231,7855272668,1815 M. Street,,Belleville,KS,66935


### PR DESCRIPTION
Pratt County appointed Lori Voss to be County Clerk on May 1, 2020 replacing Sherry Kruse. I am changing the name and email address as per Voss' request. Urgent update.