### PR TITLE
Export since date

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -69,7 +69,11 @@ def redact_pii():
 @manager.command
 def export_registrants():
     from app.services.registrant_exporter import RegistrantExporter
-    regs = Registrant.query.yield_per(200).enable_eagerloads(False)
+    if os.getenv('SINCE'):
+      regs = Registrant.query.filter(Registrant.updated_at > os.getenv('SINCE')).yield_per(200).enable_eagerloads(False)
+    else:
+      regs = Registrant.query.yield_per(200).enable_eagerloads(False)
+
     exporter = RegistrantExporter(regs)
     exporter.export()
 


### PR DESCRIPTION
Limit export to registrant records updated since a baseline timestamp.

Syntax:

`SINCE=2020-01-01 make export`

The `SINCE` value is anything supported by the timestamp psql format.

connects #502 