### PR TITLE
Fix HTML structure for hidden modal block

### DIFF
--- a/app/templates/ab/identification.html
+++ b/app/templates/ab/identification.html
@@ -32,9 +32,11 @@
 </form>
 {% endblock %}
 
+{% block hidden_modal %}
 {% with modal_body=_('5AB_id_help'), modal_title=_('important') %}
 {% include '_confirm_modal.html' %}
 {% endwith %}
+{% endblock %}
 
 {% block js_footer %}
 <script>

--- a/app/templates/ab/preview-sign.html
+++ b/app/templates/ab/preview-sign.html
@@ -72,9 +72,11 @@
 </section>
 {% endblock %}
 
+{% block hidden_modal %}
 {% with modal_body = _('6AB_sign_modal') %}
 {% include '_confirm_modal.html' %}
 {% endwith %}
+{% endblock %}
 
 {% block js_footer %}
 {% include '_signature.js' %}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -258,6 +258,9 @@
   {% block js_footer %}
 
   {% endblock %}
+
+  {% block hidden_modal %}
+  {% endblock %}
 </body>
 
 </html>


### PR DESCRIPTION
I suspect this was causing 404 requests to /favicon.ico which should now not happen.