### PR TITLE
Skip AB ID step 5 if permanent election

### DIFF
--- a/app/main/AB/AB1_election_picker.py
+++ b/app/main/AB/AB1_election_picker.py
@@ -26,6 +26,12 @@ def ab1_election_picker():
         step = Step_AB_1(form.data)
         if step.run():
             reg.update(form.data)
+
+            if 'permanent' in reg.elections():
+                reg.ab_permanent = True
+            else:
+                reg.ab_permanent = False
+
             reg.save(db.session)
             session_manager = SessionManager(reg, step)
             return redirect(session_manager.get_redirect_url())

--- a/app/main/AB/AB5_identification.py
+++ b/app/main/AB/AB5_identification.py
@@ -9,6 +9,10 @@ from app.services.steps import Step_AB_5
 @main.route('/ab/identification', methods=["GET", "POST"])
 @InSession
 def ab5_identification():
+    # skip if permanent AB application
+    if g.registrant.ab_permanent:
+        return redirect(url_for('main.ab6_preview_sign'))
+
     ab_id = g.registrant.try_value('ab_identification')
     form = FormAB5(
         ab_identification = ab_id

--- a/app/main/AB/AB7_affirmation.py
+++ b/app/main/AB/AB7_affirmation.py
@@ -39,7 +39,7 @@ def ab7_affirmation():
             r = mailer.send()
 
             # if there was no ID string defined, send the action-needed email
-            if not reg.try_value('ab_identification'):
+            if not reg.ab_permanent and not reg.try_value('ab_identification'):
                 id_action_mailer = IdActionMailer(reg, clerk)
                 resp = id_action_mailer.send()
                 reg.update({'ab_id_action_email_sent': resp['MessageId']})

--- a/app/main/tests/test_step_ab_5.py
+++ b/app/main/tests/test_step_ab_5.py
@@ -58,3 +58,16 @@ def test_valid_ab_5_redirects_to_preview(app,db_session,client):
 
     reg = Registrant.find_by_session(registrant.session_id)
     assert reg.try_value('ab_identification') == 'K00-00-0000'
+
+def test_ab_permanent_skips_step_5(app, db_session, client):
+    registrant = create_registrant(db_session)
+    registrant.ab_permanent = True
+    registrant.save(db_session)
+    with client.session_transaction() as http_session:
+        http_session['session_id'] = str(registrant.session_id)
+
+    response = client.get('/ab/identification', follow_redirects=False)
+    redirect_data = response.data.decode()
+    assert response.status_code == 302
+    assert ('/ab/preview' in redirect_data) == True
+

--- a/app/main/tests/test_step_ab_7.py
+++ b/app/main/tests/test_step_ab_7.py
@@ -65,3 +65,20 @@ def test_with_affirmation_and_ab_id(app, db_session, client):
     assert ('/ab/submission' in redirect_data) == True
     assert registrant.try_value('ab_forms_message_id') == 'set SEND_EMAIL env var to enable email'
     assert registrant.try_value('ab_id_action_email_sent') == ''
+
+def test_with_permanent_election_no_ab_id(app, db_session, client):
+    registrant = create_registrant(db_session)
+    registrant.ab_permanent = True
+    registrant.save(db_session)
+    with client.session_transaction() as http_session:
+        http_session['session_id'] = str(registrant.session_id)
+
+    form_payload = {"affirmation": "true"}
+
+    response = client.post('/ab/affirmation', data=form_payload, follow_redirects=False)
+    redirect_data = response.data.decode()
+    assert response.status_code == 302
+    assert ('/ab/submission' in redirect_data) == True
+    assert registrant.try_value('ab_forms_message_id') == 'set SEND_EMAIL env var to enable email'
+    assert registrant.try_value('ab_id_action_email_sent') == ''
+


### PR DESCRIPTION
connects #512 

If the `permanent` AB form is selected, then:
* skip the /ab/identification step completely
* do not send the action needed follow-up email
