### PR TITLE
bump ksmyvoteinfo to preserve comma between street and city in address

### DIFF
--- a/.env-ci
+++ b/.env-ci
@@ -5,7 +5,8 @@ SECRET_KEY=sekritsekritsekritsekrit
 APP_CONFIG=testing
 CRYPT_KEY=tGMAP3iPMyCaHO21WPGpYl4cFkUB7JHF8fBnvce6OzA=
 PGPASSWORD=postgres
-KSMYVOTEINFO_ENV=mock
+# TODO unknown voter test requires live lookup
+#KSMYVOTEINFO_ENV=mock
 NVRIS_URL=testing
 SERVER_NAME=test.ksvotes.org:5000
 DEMO_UUID=bf685528ca104e5794c9317740da203a

--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ You'll want to add some entries to your local `/etc/hosts` file to make using Do
 ## Create databases
 
 ```sh
-$(venv) psql -c "create database ksvotes_test;" -U postgres -h ksvotes-postgres
-$(venv) psql -c "create database ksvotes_dev;" -U postgres -h ksvotes-postgres
+$(venv) PGPASSWORD=postgres psql -c 'create database "ksvotes.org_test";' -U postgres -h ksvotes-postgres
+$(venv) PGPASSWORD=postgres psql -c 'create database "ksvotes.org_dev";' -U postgres -h ksvotes-postgres
 $(venv) psql -c "create user foo with password 'bar';" -U postgres -h ksvotes-postgres
 ```
 

--- a/app/main/VR/VR7_affirmation.py
+++ b/app/main/VR/VR7_affirmation.py
@@ -1,5 +1,5 @@
 from app.main import main
-from flask import g, url_for, render_template, redirect, request
+from flask import g, url_for, render_template, redirect, request, current_app
 from flask_babel import lazy_gettext
 from app import db
 from app.models import Registrant, Clerk
@@ -16,6 +16,7 @@ from datetime import datetime
 def vr7_affirmation():
     reg = g.registrant
     clerk = reg.try_clerk()
+    current_app.logger.debug("county={} clerk={}".format(reg.county, clerk))
     form = FormVR7()
     county_picker = CountyPicker()
 

--- a/app/main/starter_views.py
+++ b/app/main/starter_views.py
@@ -185,7 +185,7 @@ def change_county():
 
     if not new_county or new_county == existing_county:
         current_app.logger.error('unable to change county')
-        redirect(redirect_url)
+        return redirect(redirect_url)
 
     current_app.logger.debug('new county %s return to %s' % (new_county, redirect_url))
     reg.county = new_county

--- a/app/main/starter_views.py
+++ b/app/main/starter_views.py
@@ -35,6 +35,15 @@ def about_us():
     g.locale = guess_locale()
     return render_template('about.html')
 
+# do not cache dynamic content
+@main.after_request
+def add_header(r):
+    r.cache_control.no_cache = True
+    r.cache_control.no_store = True
+    r.cache_control.must_revalidate = True
+    r.headers['Pragma'] = 'no-cache'
+    r.headers['Expires'] = '0'
+    return r
 
 # step 0 / 0x
 @main.route('/', methods=["GET", "POST"])
@@ -75,7 +84,12 @@ def index():
             db.session.add(registrant)
 
         skip_sos = request.values.get('skip-sos')
-        step.run(skip_sos)
+        # always skip for DEMO user, but pretend we did not
+        if current_app.config['DEMO_UUID'] and registrant.is_demo():
+            current_app.logger.debug("skip sos for DEMO user")
+            step.run(True)
+        else:
+            step.run(skip_sos)
         registrant.reg_lookup_complete = step.reg_lookup_complete
         registrant.reg_found = True if step.reg_found else False
         registrant.dob_year = registrant.get_dob_year()

--- a/app/models/tests/test_registrant.py
+++ b/app/models/tests/test_registrant.py
@@ -59,13 +59,23 @@ def test_insert_get_registrant_start(app, db_session, client):
     assert registrant_uuid.registration_value.get('name_first') == "foo"
 
 def test_prepopulate_address(app, db_session, client):
-    sosrec = { 'Address': '123 Main St #456 Wichita, KS, 12345', 'Party': 'Republican' }
+    sosrec = { 'Address': '123 Main St #456, North Wichita, KS 12345', 'Party': 'Republican' }
     r = Registrant()
     r.populate_address(sosrec)
 
     assert r.try_value('addr') == '123 Main St'
     assert r.try_value('unit') == '# 456'
-    assert r.try_value('city') == 'Wichita'
+    assert r.try_value('city') == 'North Wichita'
+    assert r.try_value('state') == 'KS'
+    assert r.try_value('zip') == '12345'
+
+    sosrec = { 'Address': '3309 Woodside Drive, North Wichita, KS 12345', 'Party': 'Republican' }
+    r = Registrant()
+    r.populate_address(sosrec)
+
+    assert r.try_value('addr') == '3309 Woodside Drive'
+    assert r.try_value('unit') == ''
+    assert r.try_value('city') == 'North Wichita'
     assert r.try_value('state') == 'KS'
     assert r.try_value('zip') == '12345'
 

--- a/playwright/helpers.py
+++ b/playwright/helpers.py
@@ -1,5 +1,6 @@
 # helpers
 def complete_step_0(page):
+    page.set_default_timeout(10000) # 30sec is default and we want to fail faster.
     page.goto("/demo")
     page.locator("[name=email-confirm]").fill("nosuchperson@example.com")
     assert page.input_value("[name=dob]") == "01/01/2000"

--- a/playwright/test_change_or_apply.py
+++ b/playwright/test_change_or_apply.py
@@ -28,7 +28,6 @@ def test_unknown_voter(page):
     page.locator("[name=email-confirm]").fill("someone@example.com")
     click_submit(page)
     assert page.url.endswith("/change-or-apply/")
-    print(page.content())
     assert page.locator("text=You are not registered").all_text_contents() == ["You are not registered to vote."]
     clerk_table = page.locator("table.clerk-details")
     assert "Douglas" in clerk_table.inner_text()

--- a/playwright/test_change_or_apply.py
+++ b/playwright/test_change_or_apply.py
@@ -19,7 +19,7 @@ def test_advance_ballot_status(page):
     assert link.get_attribute("target") == "_blank"
 
 def test_unknown_voter(page):
-    page.goto("/forget")
+    page.goto("/")
     page.locator("[name=name_first]").fill("Some")
     page.locator("[name=name_last]").fill("Body")
     page.locator("[name=dob]").fill("01/01/2000")
@@ -28,6 +28,7 @@ def test_unknown_voter(page):
     page.locator("[name=email-confirm]").fill("someone@example.com")
     click_submit(page)
     assert page.url.endswith("/change-or-apply/")
+    print(page.content())
     assert page.locator("text=You are not registered").all_text_contents() == ["You are not registered to vote."]
     clerk_table = page.locator("table.clerk-details")
     assert "Douglas" in clerk_table.inner_text()

--- a/playwright/test_change_or_apply.py
+++ b/playwright/test_change_or_apply.py
@@ -19,7 +19,7 @@ def test_advance_ballot_status(page):
     assert link.get_attribute("target") == "_blank"
 
 def test_unknown_voter(page):
-    page.goto("/")
+    page.goto("/forget")
     page.locator("[name=name_first]").fill("Some")
     page.locator("[name=name_last]").fill("Body")
     page.locator("[name=dob]").fill("01/01/2000")

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,7 @@ idna==3.2
 itsdangerous==1.1.0
 # our 1.x Flask requires we stay at Jinja < 3.0
 Jinja2==2.11.3
-ksmyvoteinfo==1.3
+ksmyvoteinfo==1.5
 lxml==4.6.5
 Mako==1.1.4
 MarkupSafe==2.0.1


### PR DESCRIPTION
Some addresses were ambiguous w/o the comma-delimiter between street and city in address line.

https://github.com/BlueprintKansas/ksmyvoteinfo-py/pull/11 fixes that upstream.

This PR bumps the version, and also adds debugging for the CI failures that resulted because of `KSMYVOTEINFO_ENV=mock` already being set in the `.env-ci` file.